### PR TITLE
Fix build errors for XDP support when using libbpf 0.8

### DIFF
--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -72,8 +72,16 @@ jobs:
         repository: xdp-project/xdp-tools
     - name: Build/Install libxdp
       run: |
-        find /usr/bin/ -name clang*-* | sed -E 's/^(\/usr\/bin\/)(.*)(\-[0-9]*)$/ln -s -v \1\2\3 \/usr\/local\/bin\/\2/' | xargs -d '\n' -n 1 bash -c
-        find /usr/bin/ -name llc*-* | sed -E 's/^(\/usr\/bin\/)(.*)(\-[0-9]*)$/ln -s -v \1\2\3 \/usr\/local\/bin\/\2/' | xargs -d '\n' -n 1 bash -c
+        cat << EOF > /tmp/ln.sh
+        #!/bin/bash
+        for exe in `find /usr/bin/ -name clang-* | sort -r | grep '\-[0-9]*$'`; do
+            newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
+            if [ ! -f /usr/local/bin/$newexe ]; then
+                ln -s -v $exe /usr/local/bin/$newexe
+            fi
+        done
+        EOF
+        /bin/bash /tmp/ln.sh
         cd xdp-tools
         ./configure
         sudo make -j 3 libxdp_install

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -73,25 +73,25 @@ jobs:
     - name: Build/Install libxdp
       run: |
         cat << "EOF" > /tmp/ln.sh
-#!/bin/bash
-function do_lns {
-    LASTVERSION=0
-    for exe in `find /usr/bin/ -name ${1}-* | sort -nr | grep '\-[0-9]*$'`; do
-        newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
-        version=`basename $exe | rev | cut -d '-' -f 1 | rev`
+        #!/bin/bash
+        function do_lns {
+            LASTVERSION=0
+            for exe in `find /usr/bin/ -name ${1}-* | sort -nr | grep '\-[0-9]*$'`; do
+                newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
+                version=`basename $exe | rev | cut -d '-' -f 1 | rev`
 
-        if [ ! -f /usr/local/bin/$newexe ]; then
-            ln -s -v $exe /usr/local/bin/$newexe
-            LASTVERSION=$version
-        elif [ "$version" -ge "$LASTVERSION" ]; then
-            ln -f -s -v $exe /usr/local/bin/$newexe
-            LASTVERSION=$version
-        fi
-    done
-}
-do_lns clang
-do_lns llc
-EOF
+                if [ ! -f /usr/local/bin/$newexe ]; then
+                    ln -s -v $exe /usr/local/bin/$newexe
+                    LASTVERSION=$version
+                elif [ "$version" -ge "$LASTVERSION" ]; then
+                    ln -f -s -v $exe /usr/local/bin/$newexe
+                    LASTVERSION=$version
+                fi
+            done
+        }
+        do_lns clang
+        do_lns llc
+        EOF
         /bin/bash /tmp/ln.sh
         cd xdp-tools
         ./configure

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -64,7 +64,7 @@ jobs:
     - name: Checkout libxdp
       uses: actions/checkout@v2
       with:
-        path: libxdp-tools
+        path: xdp-tools
         repository: xdp-project/xdp-tools
     - name: Build/Install libxdp
       run: |

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -72,8 +72,8 @@ jobs:
         repository: xdp-project/xdp-tools
     - name: Build/Install libxdp
       run: |
-        find /usr/bin/ -name clang* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1 \1\2/' | xargs -d '\n' -n 1 bash -c
-        find /usr/bin/ -name llc* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1 \1\2/' | xargs -d '\n' -n 1 bash -c
+        find /usr/bin/ -name clang* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
+        find /usr/bin/ -name llc* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
         cd xdp-tools
         ./configure
         sudo make -j 3 libxdp_install

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -74,13 +74,13 @@ jobs:
       run: |
         cat << "EOF" > /tmp/ln.sh
         #!/bin/bash
-        for exe in `find /usr/bin/ -name clang-* | sort -r | grep '\-[0-9]*$'`; do
+        for exe in `find /usr/bin/ -name clang-* | sort -nr | grep '\-[0-9]*$'`; do
             newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
             if [ ! -f /usr/local/bin/$newexe ]; then
                 ln -s -v $exe /usr/local/bin/$newexe
             fi
         done
-        for exe in `find /usr/bin/ -name llc-* | sort -r | grep '\-[0-9]*$'`; do
+        for exe in `find /usr/bin/ -name llc-* | sort -nr | grep '\-[0-9]*$'`; do
             newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
             if [ ! -f /usr/local/bin/$newexe ]; then
                 ln -s -v $exe /usr/local/bin/$newexe

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -72,9 +72,15 @@ jobs:
         repository: xdp-project/xdp-tools
     - name: Build/Install libxdp
       run: |
-        cat << EOF > /tmp/ln.sh
+        cat << "EOF" > /tmp/ln.sh
         #!/bin/bash
         for exe in `find /usr/bin/ -name clang-* | sort -r | grep '\-[0-9]*$'`; do
+            newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
+            if [ ! -f /usr/local/bin/$newexe ]; then
+                ln -s -v $exe /usr/local/bin/$newexe
+            fi
+        done
+        for exe in `find /usr/bin/ -name llc-* | sort -r | grep '\-[0-9]*$'`; do
             newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
             if [ ! -f /usr/local/bin/$newexe ]; then
                 ln -s -v $exe /usr/local/bin/$newexe

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -72,8 +72,8 @@ jobs:
         repository: xdp-project/xdp-tools
     - name: Build/Install libxdp
       run: |
-        find /usr/bin/ -name clang* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
-        find /usr/bin/ -name llc* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
+        find /usr/bin/ -name clang*-* | sed -E 's/^(\/usr\/bin\/)(.*)(\-[0-9]*)$/ln -s -v \1\2\3 \/usr\/local\/bin\/\2/' | xargs -d '\n' -n 1 bash -c
+        find /usr/bin/ -name llc*-* | sed -E 's/^(\/usr\/bin\/)(.*)(\-[0-9]*)$/ln -s -v \1\2\3 \/usr\/local\/bin\/\2/' | xargs -d '\n' -n 1 bash -c
         cd xdp-tools
         ./configure
         sudo make -j 3 libxdp_install

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -49,7 +49,11 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt-get -y install flex bison libpcap0.8-dev libtool pkgconf autoconf automake m4 gcc clang llvm gcc-multilib
+        sudo apt install -y wget software-properties-common gnupg lsb-release
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+        sudo apt update
+        sudo apt-get -y install flex bison libpcap0.8-dev libtool pkgconf autoconf automake m4 gcc gcc-multilib
         sudo apt-get -y install build-essential dpdk-dev libelf-dev git libyaml-dev libssl-dev
         sudo apt-get -y install uthash-dev
     - name: Install PF_RING
@@ -68,6 +72,8 @@ jobs:
         repository: xdp-project/xdp-tools
     - name: Build/Install libxdp
       run: |
+        find /usr/bin/ -name clang* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
+        find /usr/bin/ -name llc* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
         cd xdp-tools
         ./configure
         sudo make -j 3 libxdp_install

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -61,6 +61,17 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install pfring
         sudo ldconfig
+    - name: Checkout libxdp
+      uses: actions/checkout@v2
+      with:
+        path: libxdp-tools
+        repository: xdp-project/xdp-tools
+    - name: Build/Install libxdp
+      run: |
+        cd xdp-tools
+        ./configure
+        sudo make -j 3 libxdp_install
+        sudo ldconfig
     - name: Checkout Libbpf
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -72,8 +72,8 @@ jobs:
         repository: xdp-project/xdp-tools
     - name: Build/Install libxdp
       run: |
-        find /usr/bin/ -name clang* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
-        find /usr/bin/ -name llc* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
+        find /usr/bin/ -name clang* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1 \1\2/' | xargs -d '\n' -n 1 bash -c
+        find /usr/bin/ -name llc* | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1 \1\2/' | xargs -d '\n' -n 1 bash -c
         cd xdp-tools
         ./configure
         sudo make -j 3 libxdp_install

--- a/.github/workflows/libtrace.yaml
+++ b/.github/workflows/libtrace.yaml
@@ -73,20 +73,25 @@ jobs:
     - name: Build/Install libxdp
       run: |
         cat << "EOF" > /tmp/ln.sh
-        #!/bin/bash
-        for exe in `find /usr/bin/ -name clang-* | sort -nr | grep '\-[0-9]*$'`; do
-            newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
-            if [ ! -f /usr/local/bin/$newexe ]; then
-                ln -s -v $exe /usr/local/bin/$newexe
-            fi
-        done
-        for exe in `find /usr/bin/ -name llc-* | sort -nr | grep '\-[0-9]*$'`; do
-            newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
-            if [ ! -f /usr/local/bin/$newexe ]; then
-                ln -s -v $exe /usr/local/bin/$newexe
-            fi
-        done
-        EOF
+#!/bin/bash
+function do_lns {
+    LASTVERSION=0
+    for exe in `find /usr/bin/ -name ${1}-* | sort -nr | grep '\-[0-9]*$'`; do
+        newexe=`basename $exe | rev | cut -d '-' -f 1 --complement | rev`
+        version=`basename $exe | rev | cut -d '-' -f 1 | rev`
+
+        if [ ! -f /usr/local/bin/$newexe ]; then
+            ln -s -v $exe /usr/local/bin/$newexe
+            LASTVERSION=$version
+        elif [ "$version" -ge "$LASTVERSION" ]; then
+            ln -f -s -v $exe /usr/local/bin/$newexe
+            LASTVERSION=$version
+        fi
+    done
+}
+do_lns clang
+do_lns llc
+EOF
         /bin/bash /tmp/ln.sh
         cd xdp-tools
         ./configure

--- a/configure.in
+++ b/configure.in
@@ -321,6 +321,12 @@ if test "$want_xdp" != no; then
                 ADD_LDFLAGS="$ADD_LDFLAGS -lbpf -lelf -lxdp"
                 libtrace_xdp=true
 
+                AC_CHECK_LIB(bpf, bpf_xdp_query_id, bpfnewer=1, bpfnewer=0,
+                        -lelf -lxdp)
+                if test "$bpffound" = 1; then
+                    AC_DEFINE(HAVE_LIBBPF_XDP_QUERYID, 1, [Set to 1 if libbpf supports bpf_xdp_query_id])
+                fi
+
                 # check for requirements to build XDP eBPF kernel
                 AC_CHECK_PROG(CLANG, [clang], [clang], [no])
                 if test "$CLANG" != "no"; then

--- a/configure.in
+++ b/configure.in
@@ -335,6 +335,18 @@ if test "$want_xdp" != no; then
                     if test "$LLC" != "no"; then
                         AC_SUBST(LLC)
                         build_ebpf=true
+                    else
+                        llc_candidates=$($CLANG --version | \
+                            awk '/ clang version/ {
+                            split($4, v, ".");
+                            printf("llc-%s.%s llc-%s llc", v[[1]], v[[2]], v[[1]])
+                        }')
+                        LLC=""
+                        AC_CHECK_PROGS([LLC], [$llc_candidates], [no])
+                        if test "$LLC" != "no"; then
+                            AC_SUBST(LLC)
+                            build_ebpf=true
+                        fi
                     fi
 
                  fi

--- a/configure.in
+++ b/configure.in
@@ -311,7 +311,7 @@ if test "$want_xdp" != no; then
     if test "$elffound" = 1; then
         AC_CHECK_LIB(xdp, xsk_socket__create, xdpfound=1, xdpfound=0, -lelf)
 
-        if test "$xdpfound" = 1
+        if test "$xdpfound" = 1; then
             # check for libbpf
             AC_CHECK_LIB(bpf, bpf_map_update_elem, bpffound=1, bpffound=0,
             -lelf -lxdp)

--- a/configure.in
+++ b/configure.in
@@ -307,32 +307,40 @@ AC_ARG_WITH(xdp, AS_HELP_STRING(--with-xdp, include XDP capture support),
 
 if test "$want_xdp" != no; then
     AC_CHECK_LIB(elf, elf_begin, elffound=1, elffound=0)
+
     if test "$elffound" = 1; then
-        # check for libbpf
-        AC_CHECK_LIB(bpf, xsk_socket__create, bpffound=1, bpffound=0, -lelf)
+        AC_CHECK_LIB(xdp, xsk_socket__create, xdpfound=1, xdpfound=0, -lelf)
 
-        if test "$bpffound" = 1; then
-            AC_DEFINE(HAVE_LIBBPF, 1, [Set to 1 if libbpf is available])
-            ADD_LDFLAGS="$ADD_LDFLAGS -lbpf -lelf"
-            libtrace_xdp=true
+        if test "$xdpfound" = 1
+            # check for libbpf
+            AC_CHECK_LIB(bpf, bpf_map_update_elem, bpffound=1, bpffound=0,
+            -lelf -lxdp)
 
-            # check for requirements to build XDP eBPF kernel
-            AC_CHECK_PROG(CLANG, [clang], [clang], [no])
-            if test "$CLANG" != "no"; then
+            if test "$bpffound" = 1; then
+                AC_DEFINE(HAVE_LIBBPF, 1, [Set to 1 if libbpf is available])
+                ADD_LDFLAGS="$ADD_LDFLAGS -lbpf -lelf -lxdp"
+                libtrace_xdp=true
 
-                AC_SUBST(CLANG)
-                llc_candidates=$($CLANG --version | \
-                    awk '/^clang version/ {
-                    split($3, v, ".");
-                    printf("llc-%s.%s llc-%s llc", v[[1]], v[[2]], v[[1]])
-                }')
-                AC_CHECK_PROGS([LLC], [$llc_candidates], [no])
-                if test "$LLC" != "no"; then
-                    AC_SUBST(LLC)
-                    build_ebpf=true
-                fi
+                # check for requirements to build XDP eBPF kernel
+                AC_CHECK_PROG(CLANG, [clang], [clang], [no])
+                if test "$CLANG" != "no"; then
 
-            fi
+                    AC_SUBST(CLANG)
+                    llc_candidates=$($CLANG --version | \
+                        awk '/^clang version/ {
+                        split($3, v, ".");
+                        printf("llc-%s.%s llc-%s llc", v[[1]], v[[2]], v[[1]])
+                    }')
+                    AC_CHECK_PROGS([LLC], [$llc_candidates], [no])
+                    if test "$LLC" != "no"; then
+                        AC_SUBST(LLC)
+                        build_ebpf=true
+                    fi
+
+                 fi
+             else
+                 libtrace_xdp=false
+             fi
         else
             libtrace_xdp=false
         fi
@@ -341,7 +349,7 @@ fi
 
 # was xdp build explicitly specified and failed
 if test "$want_xdp" = yes -a "$libtrace_xdp" = false; then
-    AC_MSG_ERROR([libelf and libbpf are required for XDP support])
+    AC_MSG_ERROR([libelf, libxdp and libbpf are required for XDP support])
 fi
 
 # was ebpf build explicitly specified and failed

--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -1628,6 +1628,19 @@ static int xdp_link_detach(struct xsk_config *cfg) {
 
     uint32_t cur_prog = 0;
 
+
+#ifdef HAVE_LIBBPF_XDP_QUERYID
+    if (bpf_xdp_query_id(cfg->ifindex, cfg->xdp_flags, &cur_prog)) {
+        return EXIT_FAIL_XDP;
+    }
+
+    if (cur_prog == cfg->xdp_prog_id) {
+        if (bpf_xdp_detach(cfg->ifindex, cfg->xdp_flags, NULL) < 0) {
+            return EXIT_FAIL_XDP;
+        }
+    }
+
+#else
     // get the current program id
     if (bpf_get_link_xdp_id(cfg->ifindex, &cur_prog, cfg->xdp_flags)) {
         return EXIT_FAIL_XDP;
@@ -1640,19 +1653,35 @@ static int xdp_link_detach(struct xsk_config *cfg) {
             return EXIT_FAIL_XDP;
         }
     }
+#endif
 
     return EXIT_OK;
 }
 
 static struct bpf_object *load_bpf_object_file(struct xsk_config *cfg, int ifindex) {
 
-    int first_prog_fd = -1;
     int err;
 
+#ifdef HAVE_LIBBPF_XDP_QUERYID
+    cfg->bpf_obj = bpf_object__open_file(cfg->bpf_filename, NULL);
+    if (libbpf_get_error(cfg->bpf_obj)) {
+        return NULL;
+    }
+    cfg->bpf_prg = bpf_object__next_program(cfg->bpf_obj, NULL);
+    bpf_program__set_type(cfg->bpf_prg, BPF_PROG_TYPE_XDP);
+    bpf_program__set_ifindex(cfg->bpf_prg, ifindex);
+
+    err = bpf_object__load(cfg->bpf_obj);
+
+    if (!err) {
+        cfg->bpf_prg_fd = bpf_program__fd(cfg->bpf_prg);
+    }
+#else
     /* This struct allow us to set ifindex, this features is used for
      * hardware offloading XDP programs (note this sets libbpf
      * bpf_program->prog_ifindex and foreach bpf_map->map_ifindex).
      */
+    int first_prog_fd = -1;
     struct bpf_prog_load_attr prog_load_attr = {
         .prog_type = BPF_PROG_TYPE_XDP,
         .ifindex   = ifindex,
@@ -1663,6 +1692,8 @@ static struct bpf_object *load_bpf_object_file(struct xsk_config *cfg, int ifind
      * loading this into the kernel via bpf-syscall
      */
     err = bpf_prog_load_xattr(&prog_load_attr, &cfg->bpf_obj, &first_prog_fd);
+#endif
+
     if (err) {
         return NULL;
     }
@@ -1674,8 +1705,13 @@ static int xdp_link_attach(struct xsk_config *cfg, int prog_fd) {
 
     int err;
 
+#ifdef HAVE_LIBBPF_XDP_QUERYID
+    err = bpf_xdp_attach(cfg->ifindex, prog_fd, cfg->xdp_flags, NULL);
+#else
     /* libbpf provide the XDP net_device link-level hook attach helper */
     err = bpf_set_link_xdp_fd(cfg->ifindex, prog_fd, cfg->xdp_flags);
+#endif
+
     if (err == -EEXIST && !(cfg->xdp_flags & XDP_FLAGS_UPDATE_IF_NOEXIST)) {
         /* Force mode didn't work, probably because a program of the
          * opposite type is loaded. Let's unload that and try loading
@@ -1687,11 +1723,20 @@ static int xdp_link_attach(struct xsk_config *cfg, int prog_fd) {
         cfg->xdp_flags &= ~XDP_FLAGS_MODES;
         cfg->xdp_flags |= (old_flags & XDP_FLAGS_SKB_MODE) ? XDP_FLAGS_DRV_MODE : XDP_FLAGS_SKB_MODE;
 
+#ifdef HAVE_LIBBPF_XDP_QUERYID
+        /* unload */
+        err = bpf_xdp_detach(cfg->ifindex, cfg->xdp_flags, NULL);
+        if (!err) {
+            err = bpf_xdp_attach(cfg->ifindex, prog_fd, old_flags, NULL);
+        }
+#else
         /* unload */
         err = bpf_set_link_xdp_fd(cfg->ifindex, -1, cfg->xdp_flags);
         if (!err)
             err = bpf_set_link_xdp_fd(cfg->ifindex, prog_fd, old_flags);
+#endif
     }
+
     if (err < 0) {
         fprintf(stderr, "ERR: "
             "ifindex(%d) link set xdp fd failed (%d): %s\n",
@@ -1705,7 +1750,7 @@ static int xdp_link_attach(struct xsk_config *cfg, int prog_fd) {
 static struct bpf_object *load_bpf_and_xdp_attach(struct xsk_config *cfg) {
 
     int err;
-    int prog_fd;
+    int prog_fd = 0;
     int offload_index = 0;
 
     /* Load the BPF-ELF object file and get back libbpf bpf_object. Supply
@@ -1725,6 +1770,7 @@ static struct bpf_object *load_bpf_and_xdp_attach(struct xsk_config *cfg) {
      * these gets attached to XDP hook, the others will get freed once this
      * process exit.
      */
+#ifndef HAVE_LIBBPF_XDP_QUERYID
     cfg->bpf_prg = bpf_object__find_program_by_title(cfg->bpf_obj, cfg->bpf_progname);
     if (!cfg->bpf_prg) {
         fprintf(stderr, "ERR: couldn't find a program in ELF section '%s'\n", cfg->bpf_filename);
@@ -1737,6 +1783,7 @@ static struct bpf_object *load_bpf_and_xdp_attach(struct xsk_config *cfg) {
         return NULL;
     }
     cfg->bpf_prg_fd = prog_fd;
+#endif
 
     /* At this point: BPF-progs are (only) loaded by the kernel, and prog_fd
      * is our select file-descriptor handle. Next step is attaching this FD
@@ -1748,7 +1795,11 @@ static struct bpf_object *load_bpf_and_xdp_attach(struct xsk_config *cfg) {
     }
 
     // get the ID of the loaded XDP program on the interface
+#ifdef HAVE_LIBBPF_XDP_QUERYID
+    err = bpf_xdp_query_id(cfg->ifindex, cfg->xdp_flags, &cfg->xdp_prog_id);
+#else
     err = bpf_get_link_xdp_id(cfg->ifindex, &cfg->xdp_prog_id, cfg->xdp_flags);
+#endif
     if (err) {
         errno = -err;
         return NULL;

--- a/lib/format_linux_xdp.c
+++ b/lib/format_linux_xdp.c
@@ -11,7 +11,7 @@
 #include "hash_toeplitz.h"
 
 #include <bpf/libbpf.h>
-#include <bpf/xsk.h>
+#include <xdp/xsk.h>
 #include <bpf/bpf.h>
 #include <poll.h>
 #include <errno.h>


### PR DESCRIPTION
There have been a number of major changes with libbpf 0.8 that broke our existing XDP support.

Firstly, many deprecated functions that we had been using were removed, so this PR will use the recommended alternatives (where available).

Secondly, some XDP-specific API methods have been moved into the libxdp library and removed entirely from libbpf, so our build process needs to check for libxdp and ensure that we link against it (if XDP support is required, of course).

There's also some hackery added to our libtrace tests github action that we need to do to make sure that libxdp is able to be built in the test environment -- mostly this is related to ensuring that the libxdp configure script is able to find the right version of clang since LLVM 10+ is required for libxdp to build.